### PR TITLE
Local path in database attach, fixes #12

### DIFF
--- a/install.config
+++ b/install.config
@@ -143,12 +143,24 @@
 	  -->
 	  <UseWindowsAuthenticationForSqlDataAccess>true</UseWindowsAuthenticationForSqlDataAccess>
 
-	  <!-- Must be defined, and folder must exist. The
-	       SQL instance must have FullControl over the
-	       folder.
-	  -->
-	  <DatabaseInstallPath>C:\Program Files\Microsoft SQL Server\MSSQL11.MSSQLSERVER\MSSQL\DATA\mypsinstall</DatabaseInstallPath>
-	
+	  <DatabaseInstallPath>
+		  <!-- Must be defined, and folder must exist. The
+		       SQL instance must have FullControl over the
+		       folder. This value is used to attach the databases
+		       in SQL. If the Unc value is missing, this is
+		       also the path used as the destination for SQL
+		       database file copying.
+		  -->
+		  <Local>C:\Program Files\Microsoft SQL Server\MSSQL12.MSSQLSERVER14\MSSQL\DATA\MyPsInstall</Local>
+		  
+		  <!-- If defined this path will be used to copy
+		       database files into the file system of the
+		       SQL server.
+		  -->
+		  <Unc>\\vmsql01\MyPsInstall</Unc>
+	  </DatabaseInstallPath>
+
+
 	  <DatabaseNamePrefix>mypsinstall_</DatabaseNamePrefix>
 
   </Database>


### PR DESCRIPTION
I would have liked to implement a function in PowerShell to transform a UNC path to a local path. The problem with this idea is that the identity the script is running under must then have administrative rights to the remote server. I doubt this will very often be the case in production environments. :)

My fix, instead, forces the user to explicitly specify the local path of the database install folder.