### PR TITLE
Permit passing a config path as an argument to the install script.

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -1,5 +1,7 @@
-# Specify a path to the .config file if you do not wish to put the .config file in the same directory as the script
-$configPath = ""
+# Specify a path to the .config file if you do not wish to put the .config file
+# in the same directory as the script
+param([string]$ConfigPath = "")
+
 $scriptDir = Split-Path (Resolve-Path $myInvocation.MyCommand.Path)
 $configSettings = $null
 # Assume there is no host console available until we can read the config file.
@@ -3851,4 +3853,4 @@ function Install-SitecoreApplication([string]$configPath, [bool]$SuppressOutputT
     }
 }
 
-Install-SitecoreApplication $configPath -SuppressOutputToScreen $FALSE
+Install-SitecoreApplication $ConfigPath -SuppressOutputToScreen $FALSE


### PR DESCRIPTION
I want to be able to configure the $configPath on a per-server basis, without needing to edit install.ps1.  If install.ps1 accepted the $configPath as a parameter, then I could create a supplementary script on each server that calls install.ps1 with the desired $configPath.

This is useful if the install.config for each server is kept under source control, all files in the same repository, which mandates the use of different paths for each server's configuration.